### PR TITLE
feat: implement JWT authentication and authorization middleware with decorators

### DIFF
--- a/hypern/auth/__init__.py
+++ b/hypern/auth/__init__.py
@@ -1,0 +1,6 @@
+# hypern/auth/__init__.py
+from .jwt import JWTAuth, JWTConfig
+from .middleware import AuthMiddleware
+from .decorators import requires_auth
+
+__all__ = ["JWTAuth", "JWTConfig", "AuthMiddleware", "requires_auth"]

--- a/hypern/auth/authorization.py
+++ b/hypern/auth/authorization.py
@@ -1,2 +1,0 @@
-class Authorization:
-    pass

--- a/hypern/auth/decorators.py
+++ b/hypern/auth/decorators.py
@@ -1,0 +1,41 @@
+import asyncio
+from functools import wraps
+from typing import Any, Callable, List, Optional
+
+from hypern.hypern import Request, Response
+from hypern.response import JSONResponse
+
+
+def requires_auth(roles: Optional[List[str]] = None):
+    """
+    A decorator to enforce authentication and authorization on an endpoint.
+
+    Args:
+        roles (Optional[List[str]]): A list of roles that are allowed to access the endpoint. If None, any authenticated user can access.
+
+    Returns:
+        Callable: The decorated function with authentication and authorization checks.
+
+    The decorator checks if the request has an 'auth' attribute. If not, it returns a 401 Unauthorized response.
+    If roles are specified, it checks if the user's role is in the allowed roles. If not, it returns a 403 Forbidden response.
+    If the function being decorated is a coroutine, it awaits the function call.
+    """
+
+    def decorator(func: Callable) -> Callable:
+        @wraps(func)
+        async def wrapper(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+            request.auth = {}
+            if not hasattr(request, "auth"):
+                return JSONResponse({"error": "Authentication required"}, status_code=401)
+
+            if roles and "role" in request.auth:
+                if request.auth["role"] not in roles:
+                    return JSONResponse({"error": "Insufficient permissions"}, status_code=403)
+            # check function is awaitable
+            if asyncio.iscoroutinefunction(func):
+                return await func(self, request, *args, **kwargs)
+            return func(self, request, *args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/hypern/auth/jwt.py
+++ b/hypern/auth/jwt.py
@@ -1,0 +1,37 @@
+# hypern/auth/jwt.py
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
+
+import jwt
+from pydantic import BaseModel
+
+
+class JWTConfig(BaseModel):
+    secret_key: str
+    algorithm: str = "HS256"
+    access_token_expire_minutes: int = 30
+    refresh_token_expire_days: int = 7
+
+
+class JWTAuth:
+    def __init__(self, config: JWTConfig):
+        self.config = config
+
+    def create_access_token(self, data: Dict[str, Any]) -> str:
+        expire = datetime.now(tz=timezone.utc) + timedelta(minutes=self.config.access_token_expire_minutes)
+        to_encode = data.copy()
+        to_encode.update({"exp": expire, "type": "access"})
+        return jwt.encode(to_encode, self.config.secret_key, algorithm=self.config.algorithm)
+
+    def create_refresh_token(self, data: Dict[str, Any]) -> str:
+        expire = datetime.now(tz=timezone.utc) + timedelta(days=self.config.refresh_token_expire_days)
+        to_encode = data.copy()
+        to_encode.update({"exp": expire, "type": "refresh"})
+        return jwt.encode(to_encode, self.config.secret_key, algorithm=self.config.algorithm)
+
+    def verify_token(self, token: str) -> Optional[Dict[str, Any]]:
+        try:
+            payload = jwt.decode(token, self.config.secret_key, algorithms=[self.config.algorithm])
+            return payload
+        except jwt.PyJWTError:
+            return None

--- a/hypern/auth/middleware.py
+++ b/hypern/auth/middleware.py
@@ -1,0 +1,31 @@
+# hypern/auth/middleware.py
+from typing import List, Optional
+
+from hypern.hypern import Request
+from hypern.response import JSONResponse
+from hypern.middleware.base import Middleware
+
+from .jwt import JWTAuth
+
+
+class AuthMiddleware(Middleware):
+    def __init__(self, jwt_auth: JWTAuth, exclude_paths: Optional[List[str]] = None):
+        self.jwt_auth = jwt_auth
+        self.exclude_paths = exclude_paths or []
+
+    async def before_request(self, request: Request):
+        if request.path in self.exclude_paths:
+            return None
+
+        auth_header = request.headers.get("Authorization")
+        if not auth_header or not auth_header.startswith("Bearer "):
+            return JSONResponse({"error": "Invalid authentication"}, status_code=401)
+
+        token = auth_header.split(" ")[1]
+        payload = self.jwt_auth.verify_token(token)
+
+        if not payload:
+            return JSONResponse({"error": "Invalid token"}, status_code=401)
+
+        request.auth = payload
+        return None

--- a/hypern/hypern.pyi
+++ b/hypern/hypern.pyi
@@ -294,6 +294,7 @@ class Request:
     remote_addr: str
     timestamp: float
     context_id: str
+    auth: Dict[str, Any]
 
     def json(self) -> Dict[str, Any]: ...
     def set_body(self, body: BodyData) -> None: ...

--- a/hypern/routing/parser.py
+++ b/hypern/routing/parser.py
@@ -8,7 +8,6 @@ import orjson
 from pydantic import BaseModel, ValidationError
 from pydash import get
 
-from hypern.auth.authorization import Authorization
 from hypern.exceptions import BadRequestException
 from hypern.exceptions import ValidationException
 from hypern.hypern import Request
@@ -82,11 +81,6 @@ class InputHandler:
             # Handle Pydantic models
             if isinstance(ptype, type) and issubclass(ptype, BaseModel):
                 kwargs[name] = await self.parse_pydantic_model(name, ptype)
-                continue
-
-            # Handle Authorization
-            if isinstance(ptype, type) and issubclass(ptype, Authorization):
-                kwargs[name] = await ptype().validate(self.request)
                 continue
 
             # Handle special parameters

--- a/hypern/routing/route.py
+++ b/hypern/routing/route.py
@@ -8,8 +8,6 @@ import yaml  # type: ignore
 from pydantic import BaseModel
 from pydantic.fields import FieldInfo
 
-from hypern.auth.authorization import Authorization
-
 from hypern.enum import HTTPMethod
 from hypern.hypern import FunctionInfo, Request
 
@@ -176,11 +174,6 @@ class Route:
         }
         self.functional_handlers = []
 
-    def _process_authorization(self, item: type, docs: Dict) -> None:
-        if isinstance(item, type) and issubclass(item, Authorization):
-            auth_obj = item()
-            docs["security"] = [{auth_obj.name: []}]
-
     def _process_model_params(self, key: str, item: type, docs: Dict) -> None:
         if not (isinstance(item, type) and issubclass(item, BaseModel)):
             return
@@ -210,7 +203,6 @@ class Route:
         _docs: Dict = {"summary": summary, "tags": self.tags, "responses": [], "name": self.name}
 
         for key, item in _inputs_dict.items():
-            self._process_authorization(item, _docs)
             self._process_model_params(key, item, _docs)
 
         self._process_response(signature.return_annotation, _docs)

--- a/src/types/request.rs
+++ b/src/types/request.rs
@@ -109,6 +109,7 @@ pub struct Request {
     pub remote_addr: String,
     pub timestamp: u32,
     pub context_id: String,
+    pub auth: HashMap<String, String>,
 }
 
 impl ToPyObject for Request {
@@ -117,6 +118,7 @@ impl ToPyObject for Request {
         let headers: Py<Header> = self.headers.clone().into_py(py).extract(py).unwrap();
         let path_params = self.path_params.clone().into_py(py).extract(py).unwrap();
         let body = self.body.clone().to_object(py).extract(py).unwrap();
+        let auth = self.auth.clone().into_py(py).extract(py).unwrap();
 
         let request = PyRequest {
             path: self.path.clone(),
@@ -124,10 +126,12 @@ impl ToPyObject for Request {
             path_params,
             headers,
             body,
+            auth,
             method: self.method.clone(),
             remote_addr: self.remote_addr.clone(),
             timestamp: self.timestamp.clone(),
             context_id: self.context_id.clone(),
+
         };
         Py::new(py, request).unwrap().as_ref(py).into()
     }
@@ -261,11 +265,12 @@ impl Request {
             query_params,
             headers: headers.clone(),
             method,
-            path_params: HashMap::new(),
             body,
             remote_addr,
             timestamp,
             context_id,
+            path_params: HashMap::new(),
+            auth: HashMap::new(),
         }
     }
 }
@@ -291,6 +296,8 @@ pub struct PyRequest {
     pub timestamp: u32,
     #[pyo3(get)]
     pub context_id: String,
+    #[pyo3(get, set)]
+    pub auth: Py<PyDict>,
 }
 
 #[pymethods]
@@ -307,6 +314,7 @@ impl PyRequest {
         context_id: String,
         remote_addr: String,
         timestamp: u32,
+        auth: Py<PyDict>,
     ) -> Self {
         Self {
             path,
@@ -318,6 +326,7 @@ impl PyRequest {
             remote_addr,
             timestamp,
             context_id,
+            auth
         }
     }
 


### PR DESCRIPTION
This pull request introduces a new authentication and authorization system using JWT tokens, along with middleware and decorators to enforce these mechanisms. It also removes the old `Authorization` class and its related code.

### Authentication and Authorization System:

* [`hypern/auth/jwt.py`](diffhunk://#diff-9bdca415cc25c3786e4157e20928d11846095ed54be00468723548ab0459df38R1-R37): Introduced `JWTAuth` class for creating and verifying JWT tokens, and `JWTConfig` for configuration settings.
* [`hypern/auth/decorators.py`](diffhunk://#diff-3caac5531bfc4f18e7071a927de1bde2ebc1444f0ef4cd7398e5c2bf3df27e82R1-R41): Added `requires_auth` decorator to enforce authentication and authorization on endpoints.
* [`hypern/auth/middleware.py`](diffhunk://#diff-97a786f1818c7510133919ef674c11cff44122549913e48e5df0c25673223706R1-R31): Implemented `AuthMiddleware` to handle token verification and attach payload to request.
* [`hypern/auth/__init__.py`](diffhunk://#diff-7d362177a808e36d81df2efd58af93e5dff3ac7d8ba32d8e7b6e702d17a0dca0R1-R6): Updated imports and `__all__` to include new authentication components.

### Removal of Old Authorization System:

* [`hypern/auth/authorization.py`](diffhunk://#diff-2c1e24b604c6823568cc1f805aaba7c50afd90fa1e25f3fcf77a6b9c3b001946L1-L2): Removed the old `Authorization` class.
* [`hypern/routing/parser.py`](diffhunk://#diff-3f0f9f1acb0aa6f40450fe2d388ce49db7933c8043e54e020656bb2e5a426659L11): Removed handling of the old `Authorization` class. [[1]](diffhunk://#diff-3f0f9f1acb0aa6f40450fe2d388ce49db7933c8043e54e020656bb2e5a426659L11) [[2]](diffhunk://#diff-3f0f9f1acb0aa6f40450fe2d388ce49db7933c8043e54e020656bb2e5a426659L87-L91)
* [`hypern/routing/route.py`](diffhunk://#diff-118bb78e182462aa0f52d67b92f963d439180cc33c45d08fe6e3102378d744ddL11-L12): Removed processing of the old `Authorization` class in route handling and swagger generation. [[1]](diffhunk://#diff-118bb78e182462aa0f52d67b92f963d439180cc33c45d08fe6e3102378d744ddL11-L12) [[2]](diffhunk://#diff-118bb78e182462aa0f52d67b92f963d439180cc33c45d08fe6e3102378d744ddL179-L183) [[3]](diffhunk://#diff-118bb78e182462aa0f52d67b92f963d439180cc33c45d08fe6e3102378d744ddL213)

### Request Object Enhancements:

* [`hypern/hypern.pyi`](diffhunk://#diff-ca9ffbe302a48bca88467f13007d8399d1685123032e1bb48d905e083ae3e664R297): Added `auth` attribute to the `Request` class to store authentication payload.
* [`src/types/request.rs`](diffhunk://#diff-12e109b743b0f3e7e76cb2735c969f98af74b012c9ac55a822bde5eb70c1bb61R112): Updated Rust `Request` struct to include `auth` field and handle its conversion for Python interoperability. [[1]](diffhunk://#diff-12e109b743b0f3e7e76cb2735c969f98af74b012c9ac55a822bde5eb70c1bb61R112) [[2]](diffhunk://#diff-12e109b743b0f3e7e76cb2735c969f98af74b012c9ac55a822bde5eb70c1bb61R121-R134) [[3]](diffhunk://#diff-12e109b743b0f3e7e76cb2735c969f98af74b012c9ac55a822bde5eb70c1bb61L264-R273) [[4]](diffhunk://#diff-12e109b743b0f3e7e76cb2735c969f98af74b012c9ac55a822bde5eb70c1bb61R299-R300) [[5]](diffhunk://#diff-12e109b743b0f3e7e76cb2735c969f98af74b012c9ac55a822bde5eb70c1bb61R317) [[6]](diffhunk://#diff-12e109b743b0f3e7e76cb2735c969f98af74b012c9ac55a822bde5eb70c1bb61R329)