### PR TITLE
feat: oauth2 for swagger document

### DIFF
--- a/hypern/auth/providers.py
+++ b/hypern/auth/providers.py
@@ -1,0 +1,36 @@
+from typing import Dict
+from dataclasses import dataclass
+
+
+@dataclass
+class OAuth2Provider:
+    name: str
+    client_id: str
+    client_secret: str
+    authorize_url: str
+    token_url: str
+    scopes: Dict[str, str]
+
+
+class OAuth2Providers:
+    @staticmethod
+    def github(client_id: str, client_secret: str) -> OAuth2Provider:
+        return OAuth2Provider(
+            name="GitHub",
+            client_id=client_id,
+            client_secret=client_secret,
+            authorize_url="https://github.com/login/oauth/authorize",
+            token_url="https://github.com/login/oauth/access_token",
+            scopes={"user": "Read user information", "repo": "Access repositories"},
+        )
+
+    @staticmethod
+    def google(client_id: str, client_secret: str) -> OAuth2Provider:
+        return OAuth2Provider(
+            name="Google",
+            client_id=client_id,
+            client_secret=client_secret,
+            authorize_url="https://accounts.google.com/o/oauth2/v2/auth",
+            token_url="https://oauth2.googleapis.com/token",
+            scopes={"profile": "Read user profile", "email": "Read user email"},
+        )

--- a/hypern/datastructures.py
+++ b/hypern/datastructures.py
@@ -1,5 +1,6 @@
-from typing import Optional
+from typing import Optional, Dict
 from pydantic import BaseModel, AnyUrl
+from dataclasses import dataclass, field
 
 
 class BaseModelWithConfig(BaseModel):
@@ -19,9 +20,59 @@ class License(BaseModelWithConfig):
 
 
 class Info(BaseModelWithConfig):
-    title: str
+    title: str = "Swagger Document"
+    version: str = "0.0.1"
     summary: Optional[str] = None
     description: Optional[str] = None
     contact: Optional[Contact] = None
     license: Optional[License] = None
-    version: str
+
+
+@dataclass
+class OAuth2Flow:
+    authorizationUrl: Optional[str] = None
+    tokenUrl: Optional[str] = None
+    refreshUrl: Optional[str] = None
+    scopes: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class OAuth2Config:
+    flows: Dict[str, OAuth2Flow]
+    description: str = "OAuth2 authentication"
+
+
+@dataclass
+class SwaggerConfig:
+    info: Info
+    oauth2_config: Optional[OAuth2Config] = None
+    openapi_url: str = "/openapi.json"
+    docs_url: str = "/docs"
+
+    def get_security_schemes(self) -> Dict:
+        if not self.oauth2_config:
+            return {}
+
+        security_schemes = {"oauth2": {"type": "oauth2", "description": self.oauth2_config.description, "flows": {}}}
+
+        for flow_name, flow in self.oauth2_config.flows.items():
+            flow_config = {}
+            if flow.authorizationUrl:
+                flow_config["authorizationUrl"] = flow.authorizationUrl
+            if flow.tokenUrl:
+                flow_config["tokenUrl"] = flow.tokenUrl
+            if flow.refreshUrl:
+                flow_config["refreshUrl"] = flow.refreshUrl
+            flow_config["scopes"] = flow.scopes
+            security_schemes["oauth2"]["flows"][flow_name] = flow_config
+
+        return security_schemes
+
+    def get_openapi_schema(self) -> Dict:
+        schema = {
+            "openapi": "3.0.3",
+            "info": self.info.model_dump(),
+            "components": {"securitySchemes": self.get_security_schemes()},
+            "security": [{"oauth2": []}] if self.oauth2_config else [],
+        }
+        return schema

--- a/hypern/openapi/schemas.py
+++ b/hypern/openapi/schemas.py
@@ -2,62 +2,9 @@
 from __future__ import annotations
 
 from hypern.hypern import BaseSchemaGenerator, Route as InternalRoute
+from hypern.datastructures import SwaggerConfig
 import typing
 import orjson
-
-
-from typing import Dict, Optional
-from dataclasses import dataclass, field
-
-
-@dataclass
-class OAuth2Flow:
-    authorizationUrl: Optional[str] = None
-    tokenUrl: Optional[str] = None
-    refreshUrl: Optional[str] = None
-    scopes: Dict[str, str] = field(default_factory=dict)
-
-
-@dataclass
-class OAuth2Config:
-    flows: Dict[str, OAuth2Flow]
-    description: str = "OAuth2 authentication"
-
-
-@dataclass
-class SwaggerConfig:
-    title: str = "Hypern API"
-    version: str = "1.0.0"
-    description: str = ""
-    oauth2_config: Optional[OAuth2Config] = None
-
-    def get_security_schemes(self) -> Dict:
-        if not self.oauth2_config:
-            return {}
-
-        security_schemes = {"oauth2": {"type": "oauth2", "description": self.oauth2_config.description, "flows": {}}}
-
-        for flow_name, flow in self.oauth2_config.flows.items():
-            flow_config = {}
-            if flow.authorizationUrl:
-                flow_config["authorizationUrl"] = flow.authorizationUrl
-            if flow.tokenUrl:
-                flow_config["tokenUrl"] = flow.tokenUrl
-            if flow.refreshUrl:
-                flow_config["refreshUrl"] = flow.refreshUrl
-            flow_config["scopes"] = flow.scopes
-            security_schemes["oauth2"]["flows"][flow_name] = flow_config
-
-        return security_schemes
-
-    def get_openapi_schema(self) -> Dict:
-        schema = {
-            "openapi": "3.0.3",
-            "info": {"title": self.title, "version": self.version, "description": self.description},
-            "components": {"securitySchemes": self.get_security_schemes()},
-            "security": [{"oauth2": []}] if self.oauth2_config else [],
-        }
-        return schema
 
 
 class EndpointInfo(typing.NamedTuple):
@@ -67,8 +14,8 @@ class EndpointInfo(typing.NamedTuple):
 
 
 class SchemaGenerator(BaseSchemaGenerator):
-    def __init__(self, base_schema: dict[str, typing.Any]) -> None:
-        self.base_schema = base_schema
+    def __init__(self, config: SwaggerConfig) -> None:
+        self.config = config
 
     def get_endpoints(self, routes: list[InternalRoute]) -> list[EndpointInfo]:
         """
@@ -89,7 +36,7 @@ class SchemaGenerator(BaseSchemaGenerator):
         return endpoints_info
 
     def get_schema(self, app) -> dict[str, typing.Any]:
-        schema = dict(self.base_schema)
+        schema = self.config.get_openapi_schema()
         schema.setdefault("paths", {})
         for route in app.router.routes:
             parsed = self.parse_docstring(route.doc)

--- a/src/openapi/schemas.rs
+++ b/src/openapi/schemas.rs
@@ -28,14 +28,14 @@ fn yaml_to_json(yaml: &Yaml) -> Value {
 #[pyclass(subclass)]
 pub struct BaseSchemaGenerator {
     #[pyo3(get, set)]
-    base_schema: Py<PyDict>,
+    config: Py<PyAny>,
 }
 
 #[pymethods]
 impl BaseSchemaGenerator {
     #[new]
-    fn new(base_schema: Py<PyDict>) -> Self {
-        BaseSchemaGenerator { base_schema }
+    fn new(config: Py<PyAny>) -> Self {
+        BaseSchemaGenerator { config }
     }
 
     fn remove_converter(&self, path: String) -> String {


### PR DESCRIPTION
This pull request includes several changes to improve the configuration and functionality of the Swagger UI documentation and OAuth2 providers in the `hypern` application. The most important changes include replacing multiple individual parameters with a single `SwaggerConfig` object, adding support for OAuth2 providers, and updating schema generation to use the new configuration object.

### Swagger UI Configuration:

* Replaced individual parameters for Swagger UI configuration with a single `SwaggerConfig` object in the `def_get` function and related methods. (`hypern/application.py`) [[1]](diffhunk://#diff-c3b1169078726d24c3c10b2c3bf05cea8af6484c5e71ccd803d4c6b95521ec80L94-R98) [[2]](diffhunk://#diff-c3b1169078726d24c3c10b2c3bf05cea8af6484c5e71ccd803d4c6b95521ec80R134) [[3]](diffhunk://#diff-c3b1169078726d24c3c10b2c3bf05cea8af6484c5e71ccd803d4c6b95521ec80L252-R148) [[4]](diffhunk://#diff-c3b1169078726d24c3c10b2c3bf05cea8af6484c5e71ccd803d4c6b95521ec80L288-R178)
* Updated the `SchemaGenerator` class to use the `SwaggerConfig` object for generating the OpenAPI schema. (`hypern/openapi/schemas.py`) [[1]](diffhunk://#diff-dd6e5f3b347690b5457e1e557978b2ea23a850763505eb7958b51d7bd11ff356R5) [[2]](diffhunk://#diff-dd6e5f3b347690b5457e1e557978b2ea23a850763505eb7958b51d7bd11ff356L16-R18) [[3]](diffhunk://#diff-dd6e5f3b347690b5457e1e557978b2ea23a850763505eb7958b51d7bd11ff356L38-R39)

### OAuth2 Providers:

* Added a new `OAuth2Provider` class and `OAuth2Providers` class with static methods for GitHub and Google OAuth2 configurations. (`hypern/auth/providers.py`)
* Introduced `OAuth2Flow` and `OAuth2Config` dataclasses to support OAuth2 flows in the Swagger configuration. (`hypern/datastructures.py`) [[1]](diffhunk://#diff-ce8140b85267b361af7df6dd93aa8d2a81702a728ac82a8191303af9571949cfL1-R3) [[2]](diffhunk://#diff-ce8140b85267b361af7df6dd93aa8d2a81702a728ac82a8191303af9571949cfL22-R78)

### General Improvements:

* Removed unused imports and refactored import statements to accommodate the new `SwaggerConfig` object. (`hypern/application.py`)
* Updated the `BaseSchemaGenerator` class in Rust to use the new configuration object. (`src/openapi/schemas.rs`)